### PR TITLE
[#15] Push 전에 lint 수행하도록 Git Hook 설치

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -16,7 +16,7 @@
     "sourceType": "module"
   },
   "plugins": ["@typescript-eslint"],
-  "ignorePatterns": ["node_modules/**", "**/dist/**"],
+  "ignorePatterns": ["node_modules/**", "**/dist/**", "**/build/**"],
   "rules": {
     "@typescript-eslint/no-unused-vars": [
       "error",

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+yarn lint

--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
+    "lint": "eslint --fix .",
+    "prepare": "husky install",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {
@@ -49,6 +51,7 @@
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^5.53.0",
-    "@typescript-eslint/parser": "^5.53.0"
+    "@typescript-eslint/parser": "^5.53.0",
+    "husky": "^8.0.3"
   }
 }

--- a/src/hooks/index.tsx
+++ b/src/hooks/index.tsx
@@ -1,7 +1,3 @@
-interface Props {
-  name: any
-}
-
-export const Index = ({ name }: Props) => {
+export const Index = () => {
   return <></>
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5038,6 +5038,11 @@ human-signals@^2.1.0:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
   integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
 
+husky@^8.0.3:
+  version "8.0.3"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-8.0.3.tgz#4936d7212e46d1dea28fef29bb3a108872cd9184"
+  integrity sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==
+
 iconv-lite@0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"


### PR DESCRIPTION
fixes #15

## Results

이제 `git push` 시 push가 실행되기 전 `yarn lint`를 수행합니다. `eslint --fix`로 수정되지 못하는 lint 오류가 발생하면 push할 수 없습니다.

## 참고 자료

https://blog.pumpkin-raccoon.com/85